### PR TITLE
tweak query to search for edited objects

### DIFF
--- a/analysis/Per-Edit-Analysis.ipynb
+++ b/analysis/Per-Edit-Analysis.ipynb
@@ -111,8 +111,8 @@
    "source": [
     "sns.set_style('whitegrid')\n",
     "hw = df[~pd.isnull(df.highway)]\n",
-    "ax = hw[hw.version==1].groupby('date').aggregate({'length':sum}).cumsum().plot(figsize=(12,8),legend=None)\n",
-    "hw[hw.version>1].groupby('date').aggregate({'length':sum}).cumsum().plot(ax=ax,legend=None)\n",
+    "ax = hw[(hw.version==1) & (hw.minorVersion==0)].groupby('date').aggregate({'length':sum}).cumsum().plot(figsize=(12,8),legend=None)\n",
+    "hw[(hw.version>1) | ((hw.version==1) & (hw.minorVersion>0))].groupby('date').aggregate({'length':sum}).cumsum().plot(ax=ax,legend=None)\n",
     "ax.set_ylabel(\"Kilometers of road edits\",fontsize=16)\n",
     "ax.set_title(\"Kilometers of road edited vs. added over time\",fontsize=16);\n",
     "ax.legend(['Added','Edited'], loc=0, fontsize=12);"
@@ -134,7 +134,7 @@
     "sns.set_style('whitegrid')\n",
     "buildings = df[~pd.isnull(df.building)]\n",
     "ax = buildings[(buildings.version==1) & (buildings.minorVersion==0)].groupby('date').aggregate({'id':'nunique'}).cumsum().plot(figsize=(12,8),legend=None)\n",
-    "buildings[buildings.version>1].groupby('date').aggregate({'id':'nunique'}).cumsum().plot(ax=ax,legend=None)\n",
+    "buildings[(buildings.version > 1) | ((buildings.version==1) & (buildings.minorVersion>0))].groupby('date').aggregate({'id':'nunique'}).cumsum().plot(ax=ax,legend=None)\n",
     "ax.set_ylabel(\"Buildings Edited\",fontsize=16)\n",
     "ax.set_title(\"Number of buildings edited vs. added over time\",fontsize=16);\n",
     "ax.legend(['Added','Edited'], loc=0, fontsize=12);"


### PR DESCRIPTION
Also version 1 elements can have "minor" versions, which must be accounted for when counting added/edited objects.

Otherwise the results leave some of the data unaccounted for. See below (top is before this PR, bottom is after):

<img src="https://user-images.githubusercontent.com/1927298/49728002-e1869e00-fc71-11e8-94ed-2bf39ff15028.png" width="40%"/> - <img src="https://user-images.githubusercontent.com/1927298/49727459-a0da5500-fc70-11e8-86f5-7fbac5bb89d9.png" width="40%"/>
